### PR TITLE
composer require not install

### DIFF
--- a/resources/docs/README.md
+++ b/resources/docs/README.md
@@ -14,7 +14,7 @@ features:
 
 
 ```bash
-$ composer install beyondcode/laravel-websockets
+$ composer require beyondcode/laravel-websockets
 
 $ php artisan websockets:serve
 ```


### PR DESCRIPTION
it should state composer require on front page, not install.