### PR TITLE
Change 'install' to 'require'

### DIFF
--- a/resources/docs/README.md
+++ b/resources/docs/README.md
@@ -14,7 +14,7 @@ features:
 
 
 ```bash
-$ composer install beyondcode/laravel-websockets
+$ composer require beyondcode/laravel-websockets
 
 $ php artisan websockets:serve
 ```


### PR DESCRIPTION
It throws error: 

Invalid argument beyondcode/laravel-websockets. Use "composer require beyondcode/laravel-websockets" instead to add packages to your composer.json.

I think it should be require