### PR TITLE
Add the missing p to https://beyondco.de

### DIFF
--- a/public/laravel-websockets/index.html
+++ b/public/laravel-websockets/index.html
@@ -23,7 +23,7 @@
 
 $ php artisan websockets:serve
 </code></pre></div></div> <div class="footer">
-    MIT Licensed | Developed by the awesome people at <a href="htts://beyondco.de">BeyondCode</a> and <a href="https://spatie.be">Spatie</a>.
+    MIT Licensed | Developed by the awesome people at <a href="https://beyondco.de">BeyondCode</a> and <a href="https://spatie.be">Spatie</a>.
   </div></div> <!----></div></div>
     <script src="/laravel-websockets/assets/js/16.035684c8.js" defer></script><script src="/laravel-websockets/assets/js/app.1c370667.js" defer></script>
   </body>

--- a/resources/docs/.vuepress/theme/Home.vue
+++ b/resources/docs/.vuepress/theme/Home.vue
@@ -43,7 +43,7 @@
     <div
       class="footer"
     >
-      MIT Licensed | Developed by the awesome people at <a href="htts://beyondco.de">BeyondCode</a> and <a href="https://spatie.be">Spatie</a>.
+      MIT Licensed | Developed by the awesome people at <a href="https://beyondco.de">BeyondCode</a> and <a href="https://spatie.be">Spatie</a>.
     </div>
   </div>
 </template>


### PR DESCRIPTION
I found out that the url on https://docs.beyondco.de/laravel-websockets/ to beyondco.de didn't work. I search for the different places where the url was htts://beyondco.de and change it to https://beyondco.de